### PR TITLE
fix for error when beneficiary_objects is empty.

### DIFF
--- a/app/Models/DueList.php
+++ b/app/Models/DueList.php
@@ -22,7 +22,7 @@ class DueList extends Eloquent {
 								->distinct()
 								->where('fk_cc_id','=',$cc_id)
 								->get();
-		
+		$beneficiary_list = [];
 		foreach($beneficiary_objects as $obj)
 			$beneficiary_list []= $obj->fk_b_id;
 		


### PR DESCRIPTION
The loop in [line](https://github.com/shashank-srikant/sevasetu-mothercare/blob/388b82ba0a806db9ccddd4913fdc7e5c1f17be8c/app/Models/DueList.php#L26) does not run and hence `$beneficiary_list` is never declared if the `$beneficiary_objects` is empty which I suppose can happen if no beneficiary is assigned to the mother. In my case this threw an exception just after logging in as a champion.
